### PR TITLE
Moving failing / failed notifications to correct activity

### DIFF
--- a/app/src/main/java/com/example/myapplication/MainActivity.java
+++ b/app/src/main/java/com/example/myapplication/MainActivity.java
@@ -4,20 +4,13 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Button;
-import android.os.Handler;
 
 public class MainActivity extends AppCompatActivity {
-    private final Handler handler = new Handler();
-    private Runnable failTask;
-    private NotificationHelper notificationHelper;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        notificationHelper = new NotificationHelper(this);
-        notificationHelper.createNotificationChannel();
 
         Button pomodoroButt = findViewById(R.id.startButton);
         pomodoroButt.setOnClickListener(v -> {
@@ -27,28 +20,5 @@ public class MainActivity extends AppCompatActivity {
 
             startActivity(intent);
         });
-    }
-
-    protected void onStart() {
-        super.onStart();
-        notificationHelper.checkNotificationPermission();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        notificationHelper.displayNotification("Come back to the app within one minute, or you will fail");
-
-        // Define the fail task
-        failTask = () -> notificationHelper.displayNotification("Failed");
-        handler.postDelayed(failTask, 60 * 1000); // 60 seconds
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // Cancel the notification and timer task
-        notificationHelper.cancelNotification();
-        handler.removeCallbacks(failTask);
     }
 }


### PR DESCRIPTION
Previously, the "failing" state notification showed up, when clicking the "Start" button, because it changes the activity, and therefore triggers `onStop`. I wasn't aware of this, moved the notification logic to the correct (PomodoroTimer) activity